### PR TITLE
[dplt-980] Add putBucketVersioning() method to S3 wrapper

### DIFF
--- a/src/aws/s3.js
+++ b/src/aws/s3.js
@@ -218,6 +218,21 @@ async function putBucketPolicy(bucket, policy, options = {}, params = {}) {
     return s3.putBucketPolicy({...requiredParams, ...params}).promise();
 }
 
+async function putBucketVersioning(bucket, mfaDeleteEnabled, versioningEnabled, options = {}, params = {}) {
+    const s3 = new AWS.S3({...commonDefaultOptions, ...regionDefaultOptions(), ...options});
+    const mfaDeleteEnabledString = mfaDeleteEnabled ? 'Enabled' : 'Disabled';
+    const versioningEnabledString = versioningEnabled ? 'Enabled' : 'Suspended';
+    const requiredParams = {
+        Bucket: bucket,
+        VersioningConfiguration: {
+            MFADelete: mfaDeleteEnabledString,
+            Status: versioningEnabledString
+        }
+    };
+
+    return s3.putBucketVersioning({...requiredParams, ...params}).promise();
+}
+
 async function readHeaderLine(bucket, key, delimiter = '\n', quote = true, options = {}, params = {}) {
     const targetStream = MemoryStream.createWriteStream();
 
@@ -311,6 +326,7 @@ module.exports = {
     objectExists,
     putBucketEncryption,
     putBucketPolicy,
+    putBucketVersioning,
     readHeaderLine,
     readLines,
     upload,

--- a/src/aws/s3.spec.js
+++ b/src/aws/s3.spec.js
@@ -791,7 +791,7 @@ describe('putBucketVersioning', () => {
     const VersioningConfiguration = {
         MFADelete: "Enabled",
         Status: "Enabled"
-    }
+    };
 
     describe('creating new S3 instance constructor', () => {
         const regionDefaultOption = 'MOCK_DEFAULT_REGION';

--- a/src/aws/s3.spec.js
+++ b/src/aws/s3.spec.js
@@ -34,6 +34,8 @@ const putBucketEncryptionPromiseFn = jest.fn();
 const putBucketEncryptionFn = jest.fn(() => ({ promise: putBucketEncryptionPromiseFn }));
 const putBucketPolicyPromiseFn = jest.fn();
 const putBucketPolicyFn = jest.fn(() => ({ promise: putBucketPolicyPromiseFn }));
+const putBucketVersioningPromiseFn = jest.fn();
+const putBucketVersioningFn = jest.fn(() => ({ promise: putBucketVersioningPromiseFn }));
 const uploadPromiseFn = jest.fn();
 const uploadFn = jest.fn(() => ({promise: uploadPromiseFn}));
 const getBucketNotificationConfigurationPromiseFn = jest.fn();
@@ -52,6 +54,7 @@ AWS.S3 = jest.fn(() => ({
     headBucket: headBucketFn,
     putBucketEncryption: putBucketEncryptionFn,
     putBucketPolicy: putBucketPolicyFn,
+    putBucketVersioning: putBucketVersioningFn,
     upload: uploadFn,
     getBucketNotificationConfiguration: getBucketNotificationConfigurationFn,
     putBucketNotificationConfiguration: putBucketNotificationConfigurationFn
@@ -79,6 +82,8 @@ const clearMocks = () => {
     putBucketEncryptionFn.mockClear();
     putBucketPolicyPromiseFn.mockClear();
     putBucketPolicyFn.mockClear();
+    putBucketVersioningPromiseFn.mockClear();
+    putBucketVersioningFn.mockClear();
     uploadPromiseFn.mockClear();
     uploadFn.mockClear();
     getBucketNotificationConfigurationPromiseFn.mockClear();
@@ -775,6 +780,72 @@ describe('putBucketPolicy', () => {
             const userDefinedParams = {Bucket: 'ANOTHER_MOCK_BUCKET', Policy: 'abc', CUSTOM_KEY: 'CUSTOM_VALUE'};
             await s3.putBucketPolicy(Bucket, Policy, {}, userDefinedParams);
             expect(putBucketPolicyFn).toBeCalledWith(userDefinedParams);
+        });
+    });
+});
+
+describe('putBucketVersioning', () => {
+    const Bucket = 'mock-bucket';
+    const mfaDeleteEnabled = true;
+    const versioningEnabled = true;
+    const VersioningConfiguration = {
+        MFADelete: "Enabled",
+        Status: "Enabled"
+    }
+
+    describe('creating new S3 instance constructor', () => {
+        const regionDefaultOption = 'MOCK_DEFAULT_REGION';
+        const AWS_DEFAULT_REGION = process.env.AWS_DEFAULT_REGION;
+
+        beforeEach(() => {
+            clearMocks();
+            process.env.AWS_DEFAULT_REGION = regionDefaultOption;
+        });
+
+        afterEach(() => {
+            process.env.AWS_DEFAULT_REGION = AWS_DEFAULT_REGION;
+        });
+
+        it('passes default options', async () => {
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled);
+            expect(AWS.S3).toBeCalledWith(expect.objectContaining({region: regionDefaultOption}));
+        });
+
+        it('passes user defined options', async () => {
+            const userDefinedOptions = {CUSTOM_KEY: 'CUSTOM_VALUE'};
+
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled, userDefinedOptions);
+            expect(AWS.S3).toBeCalledWith(expect.objectContaining({region: regionDefaultOption, ...userDefinedOptions}));
+        });
+
+        it('favours user defined options', async () => {
+            const userDefinedOptions = {region: 'CUSTOM_VALUE', CUSTOM_KEY: 'CUSTOM_VALUE'};
+
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled, userDefinedOptions);
+            expect(AWS.S3).toBeCalledWith(expect.objectContaining(userDefinedOptions));
+        });
+    });
+
+    describe('calling AWS.S3().putBucketVersioning with expected params', () => {
+        beforeEach(() => {
+            clearMocks();
+        });
+
+        it('passes required params', async () => {
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled);
+            expect(putBucketVersioningFn).toBeCalledWith({Bucket, VersioningConfiguration});
+        });
+
+        it('passes user defined params', async () => {
+            const userDefinedParams = {CUSTOM_KEY: 'CUSTOM_VALUE'};
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled, {}, userDefinedParams);
+            expect(putBucketVersioningFn).toBeCalledWith({Bucket, VersioningConfiguration, ...userDefinedParams});
+        });
+
+        it('favours user defined params', async () => {
+            const userDefinedParams = {Bucket: 'ANOTHER_MOCK_BUCKET', VersioningConfiguration: {}, CUSTOM_KEY: 'CUSTOM_VALUE'};
+            await s3.putBucketVersioning(Bucket, mfaDeleteEnabled, versioningEnabled, {}, userDefinedParams);
+            expect(putBucketVersioningFn).toBeCalledWith(userDefinedParams);
         });
     });
 });


### PR DESCRIPTION
This method is required to configure all the S3 buckets so that deleted objects can be recovered.